### PR TITLE
Reverse generation layers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
   "name": "Styler",
+  "editorType": ["figma"],
   "id": "820660579767995949",
   "api": "1.0.0",
   "main": "dist/code.js",
   "ui": "dist/ui.html",
   "menu": [
-    
+
     {
       "name": "Extract Styles",
       "command": "extract-all-styles"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,39 @@
 {
-  "name": "zzz-plugin",
+  "name": "styler-plugin",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "zzz-plugin",
+      "name": "styler-plugin",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "node": "^13.14.0"
-      },
       "devDependencies": {
-        "@figma/plugin-typings": "^1.15.0",
-        "@types/node": "^13.13.7",
+        "@figma/plugin-typings": "^1.34.1",
+        "@types/node": "^13.13.52",
         "clean-webpack-plugin": "^3.0.0",
-        "css-loader": "^3.5.3",
+        "css-loader": "^3.6.0",
         "file-loader": "^6.0.0",
         "html-webpack-inline-source-plugin": "^1.0.0-beta.2",
-        "html-webpack-plugin": "^4.0.3",
+        "html-webpack-plugin": "^4.5.2",
         "normalize.css": "^8.0.1",
         "prettier": "^1.19.1",
         "sass": "^1.26.5",
         "sass-loader": "^8.0.2",
-        "style-loader": "^1.1.3",
+        "style-loader": "^1.3.0",
         "svelte": "^3.22.3",
         "svelte-loader": "^2.13.6",
         "svg-inline-loader": "^0.8.2",
         "ts-loader": "^6.2.2",
-        "typescript": "^3.9.2",
-        "webpack": "^4.43.0",
-        "webpack-cli": "^3.3.11"
+        "typescript": "^3.9.10",
+        "webpack": "^4.46.0",
+        "webpack-cli": "^3.3.12"
       }
     },
     "node_modules/@figma/plugin-typings": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.22.0.tgz",
-      "integrity": "sha512-0Bp6lkXkgpNVGrL3LcL7tWLHahD3m5mQifYcXcHt0LzFimyWgGQAM/4csrkhdYhvfjF5KCRQNf7bSjxS60izEg==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.34.1.tgz",
+      "integrity": "sha512-em9v0liZaNCfndggqMjmLDxHj5b+lfMqpimmT05XMJLTH4Vgdf5JiziJx5xRvd3OwUH+kdimustdvzHsD9WE8Q==",
       "dev": true
     },
     "node_modules/@types/anymatch": {
@@ -74,9 +71,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "13.13.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
-      "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA==",
+      "version": "13.13.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
       "dev": true
     },
     "node_modules/@types/source-list-map": {
@@ -3593,26 +3590,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-13.14.0.tgz",
-      "integrity": "sha512-y5pClvPYkG7cTPRDmyNeCuOseyRFuZbrvQVbyAEhkfRWtfhyyu6lHYUjBSJzrSZXlbkCIlx+TKqLDAEhxc9Vkw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
-    },
     "node_modules/node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -4358,6 +4335,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -5675,9 +5653,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6625,9 +6603,9 @@
   },
   "dependencies": {
     "@figma/plugin-typings": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.22.0.tgz",
-      "integrity": "sha512-0Bp6lkXkgpNVGrL3LcL7tWLHahD3m5mQifYcXcHt0LzFimyWgGQAM/4csrkhdYhvfjF5KCRQNf7bSjxS60izEg==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.34.1.tgz",
+      "integrity": "sha512-em9v0liZaNCfndggqMjmLDxHj5b+lfMqpimmT05XMJLTH4Vgdf5JiziJx5xRvd3OwUH+kdimustdvzHsD9WE8Q==",
       "dev": true
     },
     "@types/anymatch": {
@@ -6665,9 +6643,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
-      "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA==",
+      "version": "13.13.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
       "dev": true
     },
     "@types/source-list-map": {
@@ -9610,19 +9588,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-13.14.0.tgz",
-      "integrity": "sha512-y5pClvPYkG7cTPRDmyNeCuOseyRFuZbrvQVbyAEhkfRWtfhyyu6lHYUjBSJzrSZXlbkCIlx+TKqLDAEhxc9Vkw==",
-      "requires": {
-        "node-bin-setup": "^1.0.0"
-      }
-    },
-    "node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
-    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -11310,9 +11275,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zzz-plugin",
+  "name": "styler-figma-plugin",
   "version": "1.0.0",
   "description": "",
   "scripts": {
@@ -10,27 +10,24 @@
   "author": "andrei-iancu <andrei-i@outlook.com>",
   "license": "MIT",
   "devDependencies": {
-    "@figma/plugin-typings": "^1.15.0",
-    "@types/node": "^13.13.7",
+    "@figma/plugin-typings": "^1.34.1",
+    "@types/node": "^13.13.52",
     "clean-webpack-plugin": "^3.0.0",
-    "css-loader": "^3.5.3",
+    "css-loader": "^3.6.0",
     "file-loader": "^6.0.0",
     "html-webpack-inline-source-plugin": "^1.0.0-beta.2",
-    "html-webpack-plugin": "^4.0.3",
+    "html-webpack-plugin": "^4.5.2",
     "normalize.css": "^8.0.1",
     "prettier": "^1.19.1",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
-    "style-loader": "^1.1.3",
+    "style-loader": "^1.3.0",
     "svelte": "^3.22.3",
     "svelte-loader": "^2.13.6",
     "svg-inline-loader": "^0.8.2",
     "ts-loader": "^6.2.2",
-    "typescript": "^3.9.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
-  },
-  "dependencies": {
-    "node": "^13.14.0"
+    "typescript": "^3.9.10",
+    "webpack": "^4.46.0",
+    "webpack-cli": "^3.3.12"
   }
 }

--- a/src/code/modules/config.ts
+++ b/src/code/modules/config.ts
@@ -11,6 +11,7 @@ export class Config {
   notificationTimeout: number;
   updateUsingLocalStyles: boolean;
   partialMatch: boolean;
+  reverseLayers: boolean;
 
   // stylers
   texter: Styler;
@@ -31,6 +32,7 @@ export class Config {
       notificationTimeout = defaultSettings.notificationTimeout,
       updateUsingLocalStyles = defaultSettings.updateUsingLocalStyles,
       partialMatch = defaultSettings.partialMatch,
+      reverseLayers = defaultSettings.reverseLayers,
 
       // stylers
       texterPrefix = defaultSettings.texterPrefix,
@@ -51,6 +53,7 @@ export class Config {
     this.notificationTimeout = notificationTimeout;
     this.updateUsingLocalStyles = updateUsingLocalStyles;
     this.partialMatch = partialMatch;
+    this.reverseLayers = reverseLayers;
 
     this.texter = new Styler({
       name: 'texter',

--- a/src/code/modules/default-settings.js
+++ b/src/code/modules/default-settings.js
@@ -5,6 +5,7 @@ export const defaultSettings = {
   notificationTimeout: 6000,
   updateUsingLocalStyles: false,
   partialMatch: false,
+  reverseLayers: false,
 
   // stylers
   fillerPrefix: '',

--- a/src/code/modules/layers.ts
+++ b/src/code/modules/layers.ts
@@ -149,12 +149,12 @@ export const createLayer = async (
 
 export const ungroup = (layer) => layer.parent.parent.appendChild(layer);
 
-/* 
+/*
 --- clean Selection
 --- remove unwanted layers from array
---- reorder layers to be sorted as in layer panel 
+--- reorder layers to be sorted as in layer panel
 */
-export const cleanSelection = (): SceneNode[] => {
+export const cleanSelection = ({ reverseLayers = false }): SceneNode[] => {
   const selection = excludeGroups(figma.currentPage.selection);
   const selectionByParent = Object.values(groupBy(selection, 'parent'));
   const layers: any = [];
@@ -166,5 +166,5 @@ export const cleanSelection = (): SceneNode[] => {
     layers.push(orderedGroup);
   });
 
-  return layers.flat().reverse();
+  return reverseLayers ? layers.flat() : layers.flat().reverse();
 };

--- a/src/code/modules/styles.ts
+++ b/src/code/modules/styles.ts
@@ -49,8 +49,9 @@ export const changeAllStyles = (config) => {
     texterOnly,
     partialMatch,
     updateUsingLocalStyles,
+    reverseLayers,
   } = config;
-  const layers = cleanSelection();
+  const layers = cleanSelection({ reverseLayers });
 
   if (isArrayEmpty(layers)) {
     showNofication(0, messages(counter).layers, notificationTimeout);

--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -132,6 +132,10 @@
       <span slot="label">Extend name match</span>
     </Checkbox>
 
+    <Checkbox bind:checked={uiSettings.reverseLayers}>
+      <span slot="label">Reverse generation order</span>
+    </Checkbox>
+
     <div class="helper">
       <Icon iconName={Warning} class="icon-container" />
       <span class="small">


### PR DESCRIPTION
## Description
This PR add a custom option that allow to reverse the layer generation order.
The use case is for example when you want to add custom colors from a palet and when it generated colors from the last to the first in your list.

## Old example
https://user-images.githubusercontent.com/68320951/134190160-6060f45d-682b-47b6-989d-07147e542a27.mp4

## New feature example
https://user-images.githubusercontent.com/68320951/134190196-6eee81d5-cbde-46f6-a5a7-fb3f687a0870.mp4

Of course, this feature also works for text generation, which may want to have the same behaviour as the color generation. And by default, the feature will not be checked by default so it will not change the default behaviour for the user. 